### PR TITLE
 Update go build to -buildvcs=false

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,6 @@ ADD . /app
 
 WORKDIR /app
 
-RUN go build -o main .
+RUN go build -buildvcs=false -o main .
 
 CMD ["/app/main"]


### PR DESCRIPTION
Set -buildvcs=false to disable VCS stamping.